### PR TITLE
Add dotnet build step in SonarQube analysis job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,6 +134,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           ./.sonar/scanner/dotnet-sonarscanner begin /k:"phamtiendungcw_MesBaoX" /o:"phamtiendungcw" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
+          dotnet build
           ./.sonar/scanner/dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
 
   deploy:


### PR DESCRIPTION
Add dotnet build step in SonarQube analysis job

This change introduces a `dotnet build` command between the SonarQube analysis start and end commands in the `Run SonarQube analysis` job of the `main.yml` file. This ensures that the project is built prior to completing the SonarQube analysis, which is essential for obtaining accurate code quality metrics.