### PR TITLE
Comment out GitHub Pages deployment step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -137,19 +137,19 @@ jobs:
           dotnet build
           ./.sonar/scanner/dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
 
-  deploy:
-    name: Deploy to GitHub Pages
-    needs: [build-frontend, sonar-analysis]
-    if: github.ref == 'refs/heads/master'
-    permissions:
-      pages: write
-      id-token: write
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  # deploy:
+  #   name: Deploy to GitHub Pages
+  #   needs: [build-frontend, sonar-analysis]
+  #   if: github.ref == 'refs/heads/master'
+  #   permissions:
+  #     pages: write
+  #     id-token: write
+  #   runs-on: ubuntu-latest
+  #   environment:
+  #     name: github-pages
+  #     url: ${{ steps.deployment.outputs.page_url }}
 
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v2
+  #   steps:
+  #     - name: Deploy to GitHub Pages
+  #       id: deployment
+  #       uses: actions/deploy-pages@v2


### PR DESCRIPTION
The deployment step for GitHub Pages has been commented out, including all related permissions, environment settings, and the action used for deployment. This change preserves the configuration for potential future use while preventing it from executing in the current workflow.